### PR TITLE
Split with '=' only once per line

### DIFF
--- a/src/shims.rs
+++ b/src/shims.rs
@@ -63,26 +63,16 @@ fn parse_shim_file(shim_path: &Path) -> Result<HashMap<String, String>, Error> {
         .lines()
         .filter(|l| !l.trim().is_empty())
     {
-        let mut components = line.split("=");
-        let key = match components.next() {
-            Some(k) => k.trim(),
-            None => {
-                return Err(Error::new(
-                    ErrorKind::InvalidData,
-                    format!("invalid line in shim file: {}", line),
-                ));
-            }
-        };
-        let value = match components.next() {
-            Some(v) => v.trim(),
-            None => {
-                return Err(Error::new(
-                    ErrorKind::InvalidData,
-                    format!("invalid line in shim file: {}", line),
-                ));
-            }
-        };
-        kvs.insert(key.to_string(), value.to_string());
+        if let Some((key, value)) = line.split_once("=") {
+            let key = key.trim();
+            let value = value.trim();
+            kvs.insert(key.to_string(), value.to_string());
+        } else {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("invalid line in shim file: {}", line),
+            ));
+        }
     }
 
     Ok(kvs)


### PR DESCRIPTION
Replaced the `split` method with the `split_once` method. Paths and args can now handle `=` characters.

Fixes #4 